### PR TITLE
Ensure we normalize path separators etc for comparsion

### DIFF
--- a/manifix/check.py
+++ b/manifix/check.py
@@ -7,6 +7,7 @@
 from __future__ import print_function
 
 import os
+from pathlib import PurePath
 
 from globmatch import glob_match
 
@@ -57,8 +58,8 @@ def check_iterables(source, dist, known_excludes=None):
             |= 1 if extra files were found in dist
             |= 2 if extra files were found in source that were not excluded
     """
-    source = set(source)
-    dist = set(dist)
+    source = set(PurePath(p) for p in source)
+    dist = set(PurePath(p) for p in dist)
 
     retval = 0
 

--- a/setup.py
+++ b/setup.py
@@ -27,18 +27,18 @@ setup_args = dict(
     author_email    = 'vidartf@gmail.com',
     license         = 'BSD-3',
     platforms       = "Linux, Mac OS X, Windows",
-    keywords        = ['Interactive', 'Interpreter', 'Shell', 'Web'],
+    keywords        = ['distribution', 'manifest', 'package'],
+    python_requires = '>=3.6',
     classifiers     = [
         'Intended Audience :: Developers',
         'Intended Audience :: System Administrators',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )
 
@@ -46,7 +46,6 @@ setup_args = dict(
 setuptools_args = {}
 install_requires = setuptools_args['install_requires'] = [
     'globmatch',
-    'six',
     'setuptools',
 ]
 


### PR DESCRIPTION
We achieve this by using pathlib, so that the comparisons for the set operation are handled as they should.